### PR TITLE
Ajout d'une page 404

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,8 +20,9 @@ http {
     location / {
       root   /app;
       index  index.html;
-      try_files $uri $uri/ /index.html;
     }
+
+    error_page   404              /404.html;
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
       root   /usr/share/nginx/html;

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="icon" href="<%= BASE_URL %>agence-bio.ico">
+  <title>CartoBIO</title>
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,500,700|Roboto+Mono:400,500|Material+Icons">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
+    integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css" rel="stylesheet" />
+</head>
+
+<body>
+  <h1>Page introuvable</h1>
+
+  <p><a href="/" rel="home">Accéder à cartobio.org</a>.</p>
+</body>
+
+</html>


### PR DESCRIPTION
Aujourd'hui en cas d'accès à une page inexistante (exemple : cartobio.org/truc),
l'utilisateur voit s'afficher l'application cartobio.

Je propose d'afficher explicitement une page d'erreur, plutôt que d'avoir une infinité d'URLs qui affichent la même chose.

Une autre solution serait de rediriger cartobio.org/truc vers cartobio.org/#/truc — vers le routing de la single page app).