### PR TITLE
Branche la navigation sur stats.data.gouv.fr

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,23 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css"
     integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css" rel="stylesheet" />
+  <!-- Matomo -->
+  <script defer>
+    var _paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDomains", ["*.cartobio.org"]]);
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://stats.data.gouv.fr/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '116']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>
 
 <body>

--- a/src/components/Geosearch.vue
+++ b/src/components/Geosearch.vue
@@ -42,6 +42,7 @@ export default {
           .get(req)
           .then(data => {
             this.results = this.formatListResults(data.data.features);
+            window._paq.push(['trackSiteSearch', this.searchText, false, this.results.length])
           })
           .finally(() => (this.loadingPlaces = false));
       } else {

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,12 @@ let storageOptions = {
 Vue.use(Vuetify)
 Vue.use(Storage, storageOptions)
 
+router.afterEach((to, from) => {
+  if (to.path && to.path !== from.path) {
+    window._paq.push(['trackPageView', to.name])
+  }
+})
+
 
 Vue.config.productionTip = false
 


### PR DESCRIPTION
- [x] obtenir un identifiant de site pour cartobio.org (ID:116)
- [x] ajoute le script à la page index.html
- [x] mesure les pages parcourues lorsque le routeur signale un changement d'URL
- [x] mesure les mots-clés recherchés