### PR TITLE
Ajout des données RPG 2020 (pour l'année 2019)

### DIFF
--- a/docs/ign.md
+++ b/docs/ign.md
@@ -26,7 +26,7 @@ Puis :
 1. Créer un nouvel attribut, le nommer `numparcel` et lui donner un type	`Integer`
 1. Créer un nouvel attribut, le nommer `codecultu` et lui donner un type	`String`
 1. Créer un nouvel attribut, le nommer `surfadm` et lui donner un type	`Double`
-1. Créer un nouvel attribut, le nommer `bio` et lui donner un type	`Integer`
+1. Créer un nouvel attribut, le nommer `bio` et lui donner un type	`String`
 1. Créer un nouvel attribut, le nommer `engagement` et lui donner un type `String`
 1. Créer un nouvel attribut, le nommer `semence` et lui donner un type `Integer`
 1. Créer un nouvel attribut, le nommer `maraichage` et lui donner un type `Integer`

--- a/docs/ign.md
+++ b/docs/ign.md
@@ -51,20 +51,20 @@ Ils peuvent être convertis à l'aide de l'outil [`ogr2ogr`][ogr2ogr],
 fourni par le paquet [`gdal`][gdal].
 
 ```shell
-RPG_SUFFIX="_20190603_.zip"
+RPG_SUFFIX=".zip"
 RPG_PREFIX="SURFACES-2019-PARCELLES-GRAPHIQUES-CONSTATEES_"
 
 rm -rf ./cartobio{,.zip}
 
-for FILE in $(ls *.zip); do
+for FILE in $(ls ${RPG_PREFIX}*.zip); do
   FILE_WITHOUT_SUFFIX=${FILE%${RPG_SUFFIX}};
   DEPT=${FILE_WITHOUT_SUFFIX#${RPG_PREFIX}};
   echo -n "$DEPT ";
   ogr2ogr -overwrite -nln cartobio d${DEPT} "/vsizip/${FILE}";
   ogrinfo "d${DEPT}" -dialect 'SQL' -sql 'CREATE INDEX ON cartobio USING PACAGE';
-  ogr2ogr -overwrite -nln cartobio -s_srs EPSG:2154 -t_srs EPSG:4326 -nlt POLYGON d${DEPT} d${DEPT} \
+  ogr2ogr -overwrite -nln cartobio -s_srs EPSG:2154 -t_srs EPSG:4326 d${DEPT} d${DEPT} \
     -dialect 'sqlite' -sql "SELECT (PACAGE || CAST(NUM_ILOT as character(3)) || CAST(NUM_PARCEL as character(3))) AS gid, ST_Area(GEOMETRY) AS SURF_GEO, * FROM cartobio WHERE PACAGE IN (SELECT DISTINCT PACAGE FROM cartobio WHERE BIO=1)";
-  ogr2ogr -update -append cartobio d${DEPT};
+  ogr2ogr -update -append -nlt POLYGON cartobio d${DEPT} cartobio;
 done
 
 zip -9 -r cartobio.zip cartobio

--- a/docs/postgis.md
+++ b/docs/postgis.md
@@ -1,0 +1,61 @@
+# PostGIS
+
+Un serveur Postgres avec l'extension PostGIS est à notre disposition.
+
+Y sont stockées :
+
+- les **couches RPG Bio** anonymysées (tables `anon_rpgbio_20xx`)
+
+## Pour s'y connecter
+
+1. D'abord créer un tunnel SSH :
+
+```sh
+ssh -L 65432:localhost:5432 91.134.137.224
+```
+
+L'hôte `localhost:65432` est alors disponible comme adresse de connexion,
+avec l'identifiant `docker` et un mot de passe communiqué individuellement.
+
+2. Lister les tables du RPG Bio
+
+```
+psql -h localhost -p 65432 -U docker \
+  -c "SELECT table_name FROM information_schema.tables WHERE table_schema='public'" gis
+```
+
+3. Créer la version "anonymisée" du RPG Bio
+
+Cette étape présuppose que la [couche bio+non-bio a déjà été produite](ign.md).
+La version anonymisée en est déduite.
+
+```sh
+RPG_YEAR=2020
+
+ogr2ogr --config PG_USE_COPY YES -f PGDump -nln anon_rpgbio_${RPG_YEAR} -nlt GEOMETRY -lco FID=id \
+  anon_rpgbio_${RPG_YEAR}.sql cartobio \
+  -dialect 'sqlite' -sql "SELECT CODE_CULTU as codecultu, BIO as bio, GEOMETRY as geom FROM cartobio WHERE BIO=1";
+```
+
+4. Charger le dump dans PostGis
+
+```sh
+psql -h localhost -p 65432 -U docker --file=anon_rpgbio_${RPG_YEAR}.sql gis
+```
+
+5. (Re)charger le calque dans GeoServer
+
+Se rendre sur l'[interface d'administration du GeoServer][geoserver], puis :
+
+1. Data › Layers › New Layer (from `cartobio:postgis`)
+2. `anon_rpgbio_20xx` et soit `Publish again`, soit `Publish`
+3. Data ›`Bounding Boxes` : cliquer sur **Compute from data**, puis sur **Compute from native bounds**, puis cliquer sur `Save`
+3. Tile Caching › Cocher **application/json;type=geojson**, **application/json;type=topojson** et **application/vnd.mapbox-vector-tile**, puis cliquer sur `Save`
+
+6. Profiter
+
+Le calque est désormais disponible pour être consommé du côté
+de l'application `Cartobio-Presentation`.
+
+
+[geoserver]: http://91.134.137.224:8088/geoserver/web/

--- a/package-lock.json
+++ b/package-lock.json
@@ -12744,11 +12744,6 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
-    "tilebelt": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tilebelt/-/tilebelt-1.0.1.tgz",
-      "integrity": "sha1-O79xE7P+xGjvsNkUj0u3HvEmoho="
-    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "lodash": "^4.17.15",
     "mapbox-gl": "^1.8.1",
     "sphericalmercator": "^1.0.5",
-    "tilebelt": "^1.0.1",
     "turf": "^3.0.14",
     "vue": "^2.6.11",
     "vue-ls": "^3.2.1",

--- a/src/components/AgriItem.vue
+++ b/src/components/AgriItem.vue
@@ -13,7 +13,7 @@
     </v-card-text>
   </v-card>-->
   <tr @click="selectOperator()">
-    <td>{{newAgriData.title}}</td>
+    <td><router-link :to="{name: 'mapWithPacage', params: {pacageId: newAgriData.numeroPacage}}" event="none">{{newAgriData.title}}</router-link></td>
     <td class="text-xs-right">{{newAgriData.dateEngagement}}</td>
     <td class="text-xs-right">{{newAgriData.numeroPacage}}</td>
     <td class="text-xs-right">{{newAgriData.numeroBio}}</td>
@@ -30,8 +30,6 @@ export default {
   methods: {
     selectOperator: function() {
       this.$emit("update:selectedOperator", this.newAgriData);
-      // this.selectedOperator = this.agriData;
-      // this.$store.commit("setOperator", this.agriData);
     },
     getOperatorName: agriData => {
       let user = _.find(agriData.utilisateurs, function(u) {

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -18,7 +18,7 @@
       >
         <v-btn flat class="navbar-button" title="Aller à la liste des exploitations">Exploitations</v-btn>
       </router-link>
-      <router-link v-if="currentRoute !== '/map'" to="/map" class="navbar-button">
+      <router-link v-if="!currentRoute.match(/\/map/)" to="/map" class="navbar-button">
         <v-btn flat class="navbar-button" title="Aller à la carte">Carte</v-btn>
       </router-link>
       <Login v-if="!getProfile.nom" class="navbar-button"></Login>

--- a/src/router.js
+++ b/src/router.js
@@ -1,9 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Home from './views/Home.vue'
-import Map from './views/Map.vue'
 import Stats from './views/Stats.vue'
-import AgriList from './views/AgriList.vue'
 import AppLayout from './views/AppLayout.vue'
 import store from './store.js'
 import goTo from 'vuetify/lib/components/Vuetify/goTo'
@@ -31,17 +29,24 @@ export default new Router({
     },
     {
       path: '/app',
-      name: 'appHome',
       component: AppLayout,
-      children: [{
-          path: '/map',
+      children: [
+        {
+          path: '/map/pacage/:pacageId:latLonZoom(@[0-9.-]+,[0-9.-]+,[0-9]+)?',
+          props: true,
+          name: 'mapWithPacage',
+          component: () => import(/* webpackChunkName: "app-map" */ './views/Map.vue'),
+        },
+        {
+          path: '/map:latLonZoom(@[0-9.-]+,[0-9.-]+,[0-9]+)?',
+          props: true,
           name: 'map',
-          component: Map
+          component: () => import(/* webpackChunkName: "app-map" */ './views/Map.vue'),
         },
         {
           path: '/notifications',
           name: 'notifications',
-          component: AgriList,
+          component: () => import(/* webpackChunkName: "app-notifications" */ './views/AgriList.vue'),
           beforeEnter: (to, from, next) => {
             let userCategory = store.getters.getUserCategory;
             if (userCategory !== store.getters.getCategories.oc) {

--- a/src/store.js
+++ b/src/store.js
@@ -9,7 +9,6 @@ const store =  new Vuex.Store({
         currentYear: 2020,
         userProfile: {},
         currentOperator: {},
-        disclaimer: true,
         userCategory: {},
         editMode: false,
         categories : {admin: "Admin", oc: "OC", agri: "Agri", other: "Autre"}
@@ -18,7 +17,6 @@ const store =  new Vuex.Store({
         getCurrentYear: state => state.currentYear,
         getProfile: state => state.userProfile,
         getOperator: state => state.currentOperator,
-        getDisclaimer: state => state.disclaimer,
         getUserCategory: state => state.userCategory,
         getEditMode: state => state.editMode,
         getCategories: state => state.categories
@@ -29,9 +27,6 @@ const store =  new Vuex.Store({
         },
         setOperator(state, operator) {
             state.currentOperator = operator;
-        },
-        setDisclaimer(state, bool) {
-            state.disclaimer = bool;
         },
         // category: role categories retrieved from the notifications portail API
         setUserCategory(state, category) {

--- a/src/store.js
+++ b/src/store.js
@@ -6,7 +6,7 @@ Vue.use(Vuex)
 //init store
 const store =  new Vuex.Store({
     state: {
-        currentYear: 2019,
+        currentYear: 2020,
         userProfile: {},
         currentOperator: {},
         disclaimer: true,

--- a/src/views/AgriList.vue
+++ b/src/views/AgriList.vue
@@ -4,7 +4,7 @@
     <v-divider></v-divider>
     <h1 class="mx-5">Liste des opérateurs</h1>
     <v-container fluid>
-      <v-data-table :headers="headers" :items="notificationList">
+      <v-data-table :headers="headers" :items="notificationList" :rows-per-page-items=rowsPerPageItems>
         <template v-slot:items="props">
           <AgriItem :agriData.sync="props.item" :selectedOperator.sync="selectedOperatorData"></AgriItem>
         </template>
@@ -75,8 +75,7 @@ export default {
   props: ["bus"],
   data: function() {
     return {
-      // itemsPerPageOptions: [6, 12, 18],
-      // itemsPerPage: 6,
+      rowsPerPageItems: [20, 50, 100, {text: "Tout", value: -1}],
       notificationList: [],
       loadingData: false,
       displayedNotifications: [],
@@ -107,11 +106,6 @@ export default {
         },
         { text: "Gérant", align: "right", sortable: true, value: "gerant" }
       ],
-      // numDisplayed: 51,
-      // rowsPerPageItems: [6, 12, 18],
-      // pagination: {
-      //   rowsPerPage: 6
-      // },
       filters: {
         name: "",
         pacage: "",
@@ -202,16 +196,13 @@ export default {
         return activite.nom === "Producteur";
       });
     },
-    displayMore: function() {
-      this.numDisplayed += 51;
-      this.displayedNotifications = _.take(
-        this.notificationList,
-        this.numDisplayed
-      );
-    },
     selectOperator: function() {
+      const {numeroPacage:pacageId} = this.selectedOperatorData
       this.$store.commit("setOperator", this.selectedOperatorData);
-      this.$router.push("map");
+      this.$router.push({
+        name: pacageId ? 'mapWithPacage' : 'map',
+        params: {pacageId}
+      });
     },
     cancelSelectOperator: function() {
       this.selectedOperatorData = {};

--- a/src/views/AgriList.vue
+++ b/src/views/AgriList.vue
@@ -223,7 +223,7 @@ export default {
         version: "1.1.0",
         request: "GetFeature",
         outputFormat: "GeoJSON",
-        typeName: "rpgbio2019v4",
+        typeName: "rpgbio2020v1",
         srsname: "4326",
         filter: '{"pacage":"' + this.numPacage + '"}'
       };
@@ -234,7 +234,7 @@ export default {
           process.env.VUE_APP_ESPACE_COLLAB_PASSWORD
       );
       this.loadingData = true;
-      // get 2019 parcels from the operator
+      // get 2020 parcels from the operator
       axios
         .get(process.env.VUE_APP_COLLABORATIF_ENDPOINT + "/gcms/wfs/cartobio", {
           params: params,

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -664,6 +664,13 @@ export default {
         name: pacageId ? 'mapWithPacage' : 'map',
         params: {pacageId, latLonZoom}
       })
+      .catch(error => {
+        // we can safely ignore duplicate navigation
+        // as I do not know if I can predict the upcoming url
+        if (error.name !== 'NavigationDuplicated'){
+          console.error(error);
+        }
+      })
     },
 
     loadLayers() {

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -44,17 +44,6 @@
     <v-content app>
       <!-- Map division so it takes the full width/height left -->
       <div class="map">
-        <!-- Disclaimer dialog. May be useless once in prod -->
-        <v-dialog v-model="getDisclaimer" persistent max-width="500">
-          <v-card>
-            <v-card-title class="headline"></v-card-title>
-            <v-card-text>Application en cours de développement. Données non exhaustives.</v-card-text>
-            <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn color="green darken-1" flat @click="acknowledgeDisclaimer()">J'ai compris</v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
         <v-dialog v-model="setUpParcel" persistent v-if="operator.title">
           <v-card>
             <v-card-title class="headline">Nouvelle Parcelle - {{this.operator.title}}</v-card-title>
@@ -596,10 +585,6 @@ export default {
     getOperator() {
       return this.$store.getters.getOperator;
     },
-    // display disclaimer on load ?
-    getDisclaimer() {
-      return this.$store.getters.getDisclaimer;
-    },
     // map Style
     mapStyle() {
       // To improve
@@ -827,9 +812,6 @@ export default {
         newUrl += "bbox=" + bbox.toString() + ",WGS84";
       }
       return { url: newUrl };
-    },
-    acknowledgeDisclaimer() {
-      this.$store.commit("setDisclaimer", false);
     },
     displayOperatorLayer(data) {
       this.addOperatorData(data, "2020");

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -881,8 +881,6 @@ export default {
         this.map.fitBounds(this.bboxOperator, {
           padding: this.mapPadding
         });
-      } else {
-        this.displayErrorMessage();
       }
       this.isOperatorOnMap = true;
       this.years.forEach(year => this.map.addLayer(this.layersOperator[year]));

--- a/src/views/Map.vue
+++ b/src/views/Map.vue
@@ -675,6 +675,7 @@ export default {
 
     loadLayers() {
       this.showLayersCard = true;
+
       this.years.forEach((year) => {
         // bio source
         let bioSource = {
@@ -708,6 +709,19 @@ export default {
         };
         this.anonLayers[year] = bioLayer;
         this.map.addLayer(this.anonLayers[year]);
+        this.map.addLayer({
+          id: `bio-tiles-${year}-border`,
+          type: "line",
+          source: "bio-" + year,
+          "source-layer": "anon_rpgbio_" + year,
+          minzoom: 10,
+          paint: {
+            "line-color": "#D0D32E",
+            "line-opacity": 0.9,
+            "line-width": 1
+          },
+          layout: {visibility: 'none'}
+        });
       });
 
       this.toggleLayerAnon(2020, true);
@@ -768,6 +782,16 @@ export default {
           "fill-opacity": 1
         }
       });
+      this.map.addLayer({
+        id: "highlighted-parcels-border",
+        type: "line",
+        source: "highlight",
+        paint: {
+          "line-color": "rgba(100, 200, 240, 1)",
+          "line-width": 2
+        }
+      });
+
       // selected
       this.map.addLayer({
         id: "selected-parcels",
@@ -890,7 +914,19 @@ export default {
         });
       }
       this.isOperatorOnMap = true;
-      this.years.forEach(year => this.map.addLayer(this.layersOperator[year]));
+      this.years.forEach(year => {
+        this.map.addLayer(this.layersOperator[year]);
+        this.map.addLayer({
+          ...this.layersOperator[year],
+          id: this.layersOperator[year].id + "-border",
+          type: "line",
+          paint: {
+            "line-color": "#FFF",
+            "line-opacity": 0.6,
+            "line-width": 1
+          }
+        });
+      });
       this.toggleLayerOperator("2020", true);
     },
     hoverParcel(parcel) {
@@ -989,8 +1025,10 @@ export default {
       if (this.map && this.map.getLayer(layer)) {
         if (visibility) {
           this.map.setLayoutProperty(layer, 'visibility', 'visible');
+          this.map.setLayoutProperty(layer + '-border', 'visibility', 'visible');
         } else {
           this.map.setLayoutProperty(layer, 'visibility', 'none');
+          this.map.setLayoutProperty(layer + '-border', 'visibility', 'none');
         }
       }
     },


### PR DESCRIPTION
- [x] Contrôles dans l'interface
- [x] Recherche sur PACAGE au lieu du numeroBio (car la donnée n'a pas été ajoutée à la table rpgbio2020v1)
- [x] Importer le RPG bio anonyme dans PostGIS pour que la parcelle `rpg_anon_2020` fonctionne
- [x] corriger le bug des surfaces OC bio qui s'affichent en fond blanc, au lieu de fond vert