### PR TITLE
Ajout de nouvelles mesures d'activité

### DIFF
--- a/src/components/FilterToolbar.vue
+++ b/src/components/FilterToolbar.vue
@@ -1,42 +1,46 @@
 <template>
   <div d-inline-flex>
-    <v-layout>
-      <h3 class="mx-2 my-auto">Filtres:</h3>
-      <v-flex xs12 sm6 md3>
-        <v-text-field body-1 label="Nom" v-model="tempFilters.name" class="mx-2"></v-text-field>
-      </v-flex>
-      <v-flex xs12 sm6 md3>
-        <v-text-field label="PACAGE" v-model="tempFilters.pacage" class="mx-2"></v-text-field>
-      </v-flex>
-      <v-flex xs12 sm6 md3>
-        <v-text-field label="Numéro Bio" v-model="tempFilters.numeroBio" class="mx-2"></v-text-field>
-      </v-flex>
-      <v-flex xs12 sm6 md3>
-        <v-text-field label="Numéro Client" v-model="tempFilters.numeroClient" class="mx-2"></v-text-field>
-      </v-flex>
-      <v-flex xs12 sm6 md3>
-        <v-autocomplete
-          v-model="tempFilters.department"
-          label="Département"
-          :items="departmentList"
-          item-text="label"
-          item-value="id"
-          class="mx-2"
-        ></v-autocomplete>
-      </v-flex>
-      <v-flex xs12 sm6 md3>
-        <v-text-field label="Ville" v-model="tempFilters.city" class="mx-2"></v-text-field>
-      </v-flex>
-      <v-btn class="mx-2 my-auto" color="primary" @click="applyFilters()">Appliquer les filtres</v-btn>
-      <v-btn
-        class="mx-2 my-auto"
-        color="error"
-        @click="removeFilters()"
-        tooltip="Supprimer les filtres"
-      >
-        <v-icon>delete</v-icon>
-      </v-btn>
+    <form @submit="applyFilters()">
+      <v-layout>
+        <h3 class="mx-2 my-auto">Filtres:</h3>
+        <v-flex xs12 sm6 md3>
+          <v-text-field body-1 label="Nom" v-model="tempFilters.name" class="mx-2"></v-text-field>
+        </v-flex>
+        <v-flex xs12 sm6 md3>
+          <v-text-field label="PACAGE" v-model="tempFilters.pacage" class="mx-2"></v-text-field>
+        </v-flex>
+        <v-flex xs12 sm6 md3>
+          <v-text-field label="Numéro Bio" v-model="tempFilters.numeroBio" class="mx-2"></v-text-field>
+        </v-flex>
+        <v-flex xs12 sm6 md3>
+          <v-text-field label="Numéro Client" v-model="tempFilters.numeroClient" class="mx-2"></v-text-field>
+        </v-flex>
+        <v-flex xs12 sm6 md3>
+          <v-autocomplete
+            v-model="tempFilters.department"
+            label="Département"
+            :items="departmentList"
+            item-text="label"
+            item-value="id"
+            class="mx-2"
+          ></v-autocomplete>
+        </v-flex>
+        <v-flex xs12 sm6 md3>
+          <v-text-field label="Ville" v-model="tempFilters.city" class="mx-2"></v-text-field>
+        </v-flex>
+        <v-btn class="mx-2 my-auto" type="submit" color="primary" @click="applyFilters()">
+          <v-icon>search</v-icon> Appliquer les filtres
+        </v-btn>
+        <v-btn
+          class="mx-2 my-auto"
+          color="error"
+          @click="removeFilters()"
+          tooltip="Réinitialiser les filtres"
+        >
+          <v-icon>highlight_off</v-icon>
+        </v-btn>
     </v-layout>
+  </form>
   </div>
 </template>
 
@@ -68,6 +72,8 @@ export default {
   },
   methods: {
     applyFilters() {
+      // event: category, action, value
+      window._paq.push(['trackEvent', 'operators', 'search', JSON.stringify(this.tempFilters)]);
       this.$emit("update-filters", this.tempFilters);
       this.displayFiltersDialog = false;
     },

--- a/src/components/ParcelsList.vue
+++ b/src/components/ParcelsList.vue
@@ -93,10 +93,19 @@ export default {
         "surfaceAdmissible",
         "surfaceGeometrique"
       ]);
-      this.convertToCsvAndDownload(
-        this.$store.getters.getOperator.title + ".csv",
-        rows
-      );
+
+      try {
+        const {numeroBio} = this.$store.getters.getOperator;
+        window._paq.push(['trackEvent', 'parcels', 'download', numeroBio]);
+        
+        this.convertToCsvAndDownload(
+          this.$store.getters.getOperator.title + ".csv",
+          rows
+        );
+      }
+      catch (error) {
+        window._paq.push(['trackEvent', 'parcels', 'error:download', error]);
+      }
     },
     createParcelArray(parcel) {
       let prop = parcel.properties;

--- a/src/views/AgriList.vue
+++ b/src/views/AgriList.vue
@@ -9,16 +9,22 @@
           <AgriItem :agriData.sync="props.item" :selectedOperator.sync="selectedOperatorData"></AgriItem>
         </template>
       </v-data-table>
+    </v-container>
 
+    <h1 class="mx-5">Recherche par numéro Pacage</h1>
+
+    <v-container fluid>
       <v-card>
+        <form @submit="searchPacage">
         <v-card-text>
           L'opérateur recherché n'est pas dans la liste ?
           Essayez avec un numéro de Pacage:
         </v-card-text>
         <v-card-actions>
           <v-text-field v-model="numPacage" label="numéro pacage" single-line counter></v-text-field>
-          <v-btn flat color="blue" @click="searchPacage">Rechercher</v-btn>
+          <v-btn flat type="submit" color="blue" @click="searchPacage">Rechercher</v-btn>
         </v-card-actions>
+      </form>
       </v-card>
       <v-dialog v-model="loadingData" hide-overlay persistent width="300">
         <v-card color="#b9d065">
@@ -233,8 +239,15 @@ export default {
             Authorization: "Basic " + tokenCollab
           }
         })
-        .then(data => this.displayResultSearchPacage(data.data))
-        .catch(() => (this.errorPacage = true));
+        .then(data => {
+          window._paq.push(['trackEvent', 'pacage', 'search', this.numPacage]);
+          window._paq.push(['trackSiteSearch', this.numPacage, 'pacage', data.features.length]);
+          this.displayResultSearchPacage(data.data);
+        })
+        .catch((error) => {
+          window._paq.push(['trackEvent', 'pacage', 'error:search', error]);
+          this.errorPacage = true;
+        });
     },
     displayResultSearchPacage: function(data) {
       this.loadingData = false;

--- a/src/views/AgriList.vue
+++ b/src/views/AgriList.vue
@@ -70,7 +70,7 @@ let cancel;
 
 import AgriItem from "@/components/AgriItem";
 import FilterToolbar from "@/components/FilterToolbar";
-import _ from 'lodash';    
+import _ from 'lodash';
 
 export default {
   name: "AgriList",
@@ -151,24 +151,26 @@ export default {
       if (this.filters.department === 1) {
         this.filters.department = undefined;
       }
-      this.getAgriList();
+
+      this.getAgriList().then(() => {
+        window._paq.push(['trackSiteSearch', JSON.stringify(newFilters), 'operators', this.notificationList.length])
+      })
     },
     getAgriList() {
       this.loadingData = true;
-      this.getNotificationsList()
-        .then(
-          function(data) {
-            this.notificationList = data.data;
-            this.displayedNotifications = _.take(
-              this.notificationList,
-              this.numDisplayed
-            );
-            _.remove(this.notificationList, function(notif) {
-              return !notif.numeroBio;
-            });
-          }.bind(this)
-        )
-        .then(() => (this.loadingData = false));
+
+      return this.getNotificationsList()
+        .then((data) => {
+          this.notificationList = data.data;
+          this.displayedNotifications = _.take(
+            this.notificationList,
+            this.numDisplayed
+          );
+          _.remove(this.notificationList, function(notif) {
+            return !notif.numeroBio;
+          });
+        })
+      .then(() => (this.loadingData = false));
     },
     getNotificationsList: function() {
       let ocId = _.get(this.getProfile, "organismeCertificateurId");
@@ -203,7 +205,10 @@ export default {
       });
     },
     selectOperator: function() {
-      const {numeroPacage:pacageId} = this.selectedOperatorData
+      // event: category, action, value
+      const {numeroBio, numeroPacage:pacageId} = this.selectedOperatorData;
+      window._paq.push(['trackEvent', 'parcels', 'display-on-map', numeroBio]);
+
       this.$store.commit("setOperator", this.selectedOperatorData);
       this.$router.push({
         name: pacageId ? 'mapWithPacage' : 'map',
@@ -211,6 +216,8 @@ export default {
       });
     },
     cancelSelectOperator: function() {
+      // event: category, action, value
+      window._paq.push(['trackEvent', 'parcels', 'cancel:display-on-map']);
       this.selectedOperatorData = {};
       this.$store.commit("setOperator", this.selectedOperatorData);
     },


### PR DESCRIPTION
- [x] affichage des parcelles d'un opérateur (via onglet Exploitations)
- [x] recherche d'un opérateur dans l'onglet Exploitations
- [x] recherche d'un numéro Pacage dans l'onglet Exploitations
- [x] téléchargement d'un parcellaire au format CSV sur la carte

Au passage, j'ai fait en sorte que les formulaires (filtres, pacage) se soumettent en appuyant sur la touche `Entrée` du clavier lorsque le focus est dans un champ de saisie.

Il y a 1 commit par métrique pour faciliter la lecture de la revue.