### PR TITLE
Utilisation des endpoints HTTPS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,12 +20,12 @@ jobs:
       run: env | grep VUE_APP > .env.production.local
       env:
         VUE_APP_API_IGN: ${{ secrets.VUE_APP_API_IGN }}
-        VUE_APP_GEOSERVER_PREFIX: "http://91.134.137.224:8088/geoserver/gwc/service/tms/1.0.0/cartobio:anon_rpgbio_"
+        VUE_APP_GEOSERVER_PREFIX: "https://cartobio.org/geoserver/gwc/service/tms/1.0.0/cartobio:anon_rpgbio_"
         VUE_APP_GEOSERVER_SUFFIX: "@EPSG:900913@pbf/{z}/{x}/{y}.pbf"
         VUE_APP_ESPACE_COLLAB_LOGIN: ${{ secrets.VUE_APP_ESPACE_COLLAB_LOGIN }}
         VUE_APP_ESPACE_COLLAB_PASSWORD: ${{ secrets.VUE_APP_ESPACE_COLLAB_PASSWORD }}
-        VUE_APP_NOTIFICATIONS_ENDPOINT: "http://cartobio.org:8000/notifications"
-        VUE_APP_COLLABORATIF_ENDPOINT: "http://cartobio.org:8000/espacecollaboratif"
+        VUE_APP_NOTIFICATIONS_ENDPOINT: "https://cartobio.org/api/notifications"
+        VUE_APP_COLLABORATIF_ENDPOINT: "https://cartobio.org/api/espacecollaboratif"
 
     - uses: jerray/publish-docker-action@v1.0.3
       with:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -19,12 +19,12 @@ jobs:
       - run: npm run build
         env:
           VUE_APP_API_IGN: ${{ secrets.VUE_APP_API_IGN }}
-          VUE_APP_GEOSERVER_PREFIX: "http://91.134.137.224:8088/geoserver/gwc/service/tms/1.0.0/cartobio:anon_rpgbio_"
+          VUE_APP_GEOSERVER_PREFIX: "https://cartobio.org/geoserver/gwc/service/tms/1.0.0/cartobio:anon_rpgbio_"
           VUE_APP_GEOSERVER_SUFFIX: "@EPSG:900913@pbf/{z}/{x}/{y}.pbf"
           VUE_APP_ESPACE_COLLAB_LOGIN: ${{ secrets.VUE_APP_ESPACE_COLLAB_LOGIN }}
           VUE_APP_ESPACE_COLLAB_PASSWORD: ${{ secrets.VUE_APP_ESPACE_COLLAB_PASSWORD }}
-          VUE_APP_NOTIFICATIONS_ENDPOINT: "http://cartobio.org:8000/notifications"
-          VUE_APP_COLLABORATIF_ENDPOINT: "http://cartobio.org:8000/espacecollaboratif"
+          VUE_APP_NOTIFICATIONS_ENDPOINT: "https://cartobio.org/api/notifications"
+          VUE_APP_COLLABORATIF_ENDPOINT: "https://cartobio.org/api/espacecollaboratif"
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.0.1


### PR DESCRIPTION
Maintenant que le site est servi en HTTPS, les appels à l'API doivent l'être pour éviter les mix insecure HTTPS/HTTP.