### PR TITLE
L'export de données prend en compte les MULTIPOLYGON

### DIFF
--- a/bin/export
+++ b/bin/export
@@ -88,7 +88,7 @@ async function run (FILTERING_FILES) {
 
   const filteringFiles = await glob(FILTERING_FILES)
   const sourceFiles = await glob(SOURCE_FILES)
-  const datasetCount = epci ? 1 : filteringFiles.length
+  const datasetCount = filteringFiles.length + (epci ? 1 : 0)
 
   // 1. Open datasets
   // shapefiles
@@ -118,11 +118,13 @@ async function run (FILTERING_FILES) {
 
     datasets.push(dataset)
   }
+
   // Filter by shapefile
-  else if (shapefiles) {
-    datasets = filteringFiles
-        .map(path => resolve(path))
-        .map(path => gdal.open(path, 'r'))
+  if (shapefiles) {
+    filteringFiles
+      .map(path => resolve(path))
+      .map(path => gdal.open(path, 'r'))
+      .forEach(dataset => datasets.push(dataset))
   }
 
   // 2. Collect all the features from each layer

--- a/src/workers/shapefile.js
+++ b/src/workers/shapefile.js
@@ -8,8 +8,14 @@ function extractFeatures({sourceFile, filteringFeatures}) {
   const filteringFeaturesPolygon = new gdal.MultiPolygon()
 
   filteringFeatures.forEach(feature => {
-    filteringFeaturesPolygon.children.add(gdal.Geometry.fromGeoJson(feature))
-  })
+    const geometry = gdal.Geometry.fromGeoJson(feature);
+
+    // we loop over MULTIPOLYGON children (POLYGONs), or a POLYGON directly
+    // eslint-disable-next-line no-unexpected-multiline
+    (geometry.name === 'MULTIPOLYGON' ? geometry.children : [geometry]).forEach(g => {
+      filteringFeaturesPolygon.children.add(g);
+    })
+  });
 
   const filterGeometry = filteringFeaturesPolygon.unionCascaded()
 


### PR DESCRIPTION
C'était essentiel avec les Shapefiles du Havre.

Et en bonus, on peut cumuler les 2 options, `--epci` _et_ `--shapefiles`.